### PR TITLE
Fix WhiteNoise capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Before setting up the project, make sure you have the following installed:
 
 ## Deployment
 
-### 1. Whitenoise Setup
+### 1. WhiteNoise Setup
 
-This project uses Whitenoise for serving static files in production. Ensure you have Whitenoise installed:
+This project uses WhiteNoise for serving static files in production. Ensure you have WhiteNoise installed:
 
 ```bash
 pip install whitenoise


### PR DESCRIPTION
## Summary
- fix capitalization of WhiteNoise in deployment docs

## Testing
- `grep -n Whitenoise README.md`


------
https://chatgpt.com/codex/tasks/task_e_6880a1bf3bbc83278fdbb2013df5be16